### PR TITLE
Fix swipe up white bar bug

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -127,12 +127,22 @@ class ChatWindow(QMainWindow):
         <html>
         <head>
             <style>
+                html, body {
+                    margin: 0;
+                    padding: 0;
+                    height: 100%;
+                    overflow: hidden;
+                }
                 .chat-container {
                     display: flex;
                     flex-direction: column;
                     padding: 10px;
-                    height: 300px;
+                    min-height: 300px;
+                    max-height: 100vh;
                     overflow-y: auto;
+                    scroll-behavior: smooth;
+                    background-color: white;
+                    box-sizing: border-box;
                 }
                 .chat-message {
                     max-width: 60%;


### PR DESCRIPTION
Fix abnormal white bars appearing when scrolling up in the chat interface by adjusting CSS height management and scroll behavior.

The original chat container had a fixed height, which caused rendering issues and white gaps when content exceeded this height and the user scrolled. The changes introduce dynamic height, a consistent background, and proper viewport handling to ensure smooth scrolling without visual artifacts.

---
<a href="https://cursor.com/background-agent?bcId=bc-98498cf1-f785-4292-997c-8702fe6766ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98498cf1-f785-4292-997c-8702fe6766ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

